### PR TITLE
fix(eslint): extraneous-dependencies

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,12 +36,6 @@ module.exports = {
 	},
 	plugins: ["react"],
 	rules: {
-		"import/no-extraneous-dependencies": [
-			"error",
-			{
-				devDependencies: true,
-				packageDir: "./",
-			},
-		],
+		"import/no-extraneous-dependencies": "off",
 	},
 }


### PR DESCRIPTION
Fixe: some of the components are showing this eslint error. 

![image](https://github.com/wpmudev/sui-docs/assets/39377174/f863406e-d00b-4ee0-9b8c-0b4ad3fabc97)
